### PR TITLE
[rocksandra] optimize partition meta data read performance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -611,6 +611,7 @@ set(SOURCES
         utilities/blob_db/blob_log_format.cc
         utilities/blob_db/ttl_extractor.cc
         utilities/cassandra/cassandra_compaction_filter.cc
+        utilities/cassandra/partition_meta_data.cc
         utilities/cassandra/format.cc
         utilities/cassandra/merge_operator.cc
         utilities/checkpoint/checkpoint_impl.cc
@@ -933,6 +934,7 @@ if(WITH_TESTS)
         utilities/backupable/backupable_db_test.cc
         utilities/blob_db/blob_db_test.cc
         utilities/cassandra/cassandra_functional_test.cc
+        utilities/cassandra/cassandra_partition_meta_data_test.cc
         utilities/cassandra/cassandra_format_test.cc
         utilities/cassandra/cassandra_row_merge_test.cc
         utilities/cassandra/cassandra_serialize_test.cc

--- a/Makefile
+++ b/Makefile
@@ -466,6 +466,7 @@ TESTS = \
 	stringappend_test \
 	cassandra_format_test \
 	cassandra_functional_test \
+	cassandra_partition_meta_data_test \
 	cassandra_row_merge_test \
 	cassandra_serialize_test \
 	ttl_test \
@@ -1096,6 +1097,9 @@ cassandra_format_test: utilities/cassandra/cassandra_format_test.o utilities/cas
 	$(AM_LINK)
 
 cassandra_functional_test: utilities/cassandra/cassandra_functional_test.o utilities/cassandra/test_utils.o $(LIBOBJECTS) $(TESTHARNESS)
+	$(AM_LINK)
+
+cassandra_partition_meta_data_test: utilities/cassandra/cassandra_partition_meta_data_test.o utilities/cassandra/test_utils.o $(LIBOBJECTS) $(TESTHARNESS)
 	$(AM_LINK)
 
 cassandra_row_merge_test: utilities/cassandra/cassandra_row_merge_test.o utilities/cassandra/test_utils.o $(LIBOBJECTS) $(TESTHARNESS)

--- a/TARGETS
+++ b/TARGETS
@@ -236,6 +236,7 @@ cpp_library(
         "utilities/blob_db/blob_log_writer.cc",
         "utilities/blob_db/ttl_extractor.cc",
         "utilities/cassandra/cassandra_compaction_filter.cc",
+        "utilities/cassandra/partition_meta_data.cc",
         "utilities/cassandra/format.cc",
         "utilities/cassandra/merge_operator.cc",
         "utilities/checkpoint/checkpoint_impl.cc",
@@ -398,6 +399,11 @@ ROCKS_TESTS = [
     [
         "cassandra_functional_test",
         "utilities/cassandra/cassandra_functional_test.cc",
+        "serial",
+    ],
+    [
+        "cassandra_partition_meta_data_test",
+        "utilities/cassandra/cassandra_partition_meta_data_test.cc",
         "serial",
     ],
     [

--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -32,6 +32,7 @@ set(JNI_NATIVE_SOURCES
         rocksjni/rocks_callback_object.cc
         rocksjni/cassandra_compactionfilterjni.cc
         rocksjni/cassandra_value_operator.cc
+        rocksjni/cassandra_partition_meta_datajni.cc
         rocksjni/cassandra_partition_meta_merge_operator.cc
         rocksjni/restorejni.cc
         rocksjni/rocksdb_exception_test.cc
@@ -67,6 +68,7 @@ set(NATIVE_JAVA_CLASSES
         org.rocksdb.Cache
         org.rocksdb.CassandraCompactionFilter
         org.rocksdb.CassandraValueMergeOperator
+        org.rocksdb.CassandraPartitionMetaData
         org.rocksdb.CassandraPartitionMetaMergeOperator
         org.rocksdb.Checkpoint
         org.rocksdb.ClockCache
@@ -172,6 +174,7 @@ add_jar(
   src/main/java/org/rocksdb/Cache.java
   src/main/java/org/rocksdb/CassandraCompactionFilter.java
   src/main/java/org/rocksdb/CassandraValueMergeOperator.java
+  src/main/java/org/rocksdb/CassandraPartitionMetaData.java
   src/main/java/org/rocksdb/CassandraPartitionMetaMergeOperator.java
   src/main/java/org/rocksdb/Checkpoint.java
   src/main/java/org/rocksdb/ChecksumType.java

--- a/java/Makefile
+++ b/java/Makefile
@@ -10,6 +10,7 @@ NATIVE_JAVA_CLASSES = org.rocksdb.AbstractCompactionFilter\
 	org.rocksdb.ClockCache\
 	org.rocksdb.CassandraCompactionFilter\
 	org.rocksdb.CassandraValueMergeOperator\
+	org.rocksdb.CassandraPartitionMetaData\
 	org.rocksdb.CassandraPartitionMetaMergeOperator\
 	org.rocksdb.ColumnFamilyHandle\
 	org.rocksdb.ColumnFamilyOptions\

--- a/java/rocksjni/cassandra_compactionfilterjni.cc
+++ b/java/rocksjni/cassandra_compactionfilterjni.cc
@@ -15,30 +15,27 @@
  */
 jlong Java_org_rocksdb_CassandraCompactionFilter_createNewCassandraCompactionFilter0(
     JNIEnv* /*env*/, jclass /*jcls*/, jboolean purge_ttl_on_expiration,
-    jboolean ignore_range_delete_on_read, jint gc_grace_period_in_seconds,
-    jint token_length) {
+    jboolean ignore_range_delete_on_read, jint gc_grace_period_in_seconds) {
   auto* compaction_filter = new rocksdb::cassandra::CassandraCompactionFilter(
       purge_ttl_on_expiration, ignore_range_delete_on_read,
-      gc_grace_period_in_seconds, token_length);
+      gc_grace_period_in_seconds);
   // set the native handle to our native compaction filter
   return reinterpret_cast<jlong>(compaction_filter);
 }
 
 /*
  * Class:     org_rocksdb_CassandraCompactionFilter
- * Method:    setMetaCfHandle
+ * Method:    setPartitionMetaData
  * Signature: (JJ)V
  */
 JNIEXPORT void JNICALL
-Java_org_rocksdb_CassandraCompactionFilter_setMetaCfHandle(
+Java_org_rocksdb_CassandraCompactionFilter_setPartitionMetaData(
     JNIEnv* /*env*/, jclass /*jcls*/, jlong compaction_filter_pointer,
-    jlong rocksdb_pointer, jlong meta_cf_handle_pointer) {
+    jlong meta_data_pointer) {
   auto* compaction_filter =
       reinterpret_cast<rocksdb::cassandra::CassandraCompactionFilter*>(
           compaction_filter_pointer);
-  auto* db = reinterpret_cast<rocksdb::DB*>(rocksdb_pointer);
-  auto* meta_cf_handle =
-      reinterpret_cast<rocksdb::ColumnFamilyHandle*>(meta_cf_handle_pointer);
-
-  compaction_filter->SetMetaCfHandle(db, meta_cf_handle);
+  auto* meta_data = reinterpret_cast<rocksdb::cassandra::PartitionMetaData*>(
+      meta_data_pointer);
+  compaction_filter->SetPartitionMetaData(meta_data);
 }

--- a/java/rocksjni/cassandra_compactionfilterjni.cc
+++ b/java/rocksjni/cassandra_compactionfilterjni.cc
@@ -16,10 +16,10 @@
 jlong Java_org_rocksdb_CassandraCompactionFilter_createNewCassandraCompactionFilter0(
     JNIEnv* /*env*/, jclass /*jcls*/, jboolean purge_ttl_on_expiration,
     jboolean ignore_range_delete_on_read, jint gc_grace_period_in_seconds,
-    jint partition_key_length) {
+    jint token_length) {
   auto* compaction_filter = new rocksdb::cassandra::CassandraCompactionFilter(
       purge_ttl_on_expiration, ignore_range_delete_on_read,
-      gc_grace_period_in_seconds, partition_key_length);
+      gc_grace_period_in_seconds, token_length);
   // set the native handle to our native compaction filter
   return reinterpret_cast<jlong>(compaction_filter);
 }

--- a/java/rocksjni/cassandra_partition_meta_datajni.cc
+++ b/java/rocksjni/cassandra_partition_meta_datajni.cc
@@ -68,6 +68,41 @@ Java_org_rocksdb_CassandraPartitionMetaData_deletePartition(
 
 /*
  * Class:     org_rocksdb_CassandraPartitionMetaData
+ * Method:    applyRaw
+ * Signature: (J[B[B)V
+ */
+JNIEXPORT void JNICALL Java_org_rocksdb_CassandraPartitionMetaData_applyRaw(
+    JNIEnv* env, jobject /*obj*/, jlong meta_data_pointer, jbyteArray jkey,
+    jbyteArray jval) {
+  jbyte* key = env->GetByteArrayElements(jkey, nullptr);
+  if (key == nullptr) {
+    // exception thrown: OutOfMemoryError
+    return;
+  }
+  jbyte* val = env->GetByteArrayElements(jval, nullptr);
+  if (val == nullptr) {
+    // exception thrown: OutOfMemoryError
+    return;
+  }
+  rocksdb::Slice key_slice(reinterpret_cast<char*>(key),
+                           env->GetArrayLength(jkey));
+  rocksdb::Slice val_slice(reinterpret_cast<char*>(val),
+                             env->GetArrayLength(jval));
+
+  auto* meta_data = reinterpret_cast<rocksdb::cassandra::PartitionMetaData*>(
+      meta_data_pointer);
+  rocksdb::Status s = meta_data->ApplyRaw(key_slice, val_slice);
+
+  env->ReleaseByteArrayElements(jkey, key, JNI_ABORT);
+  env->ReleaseByteArrayElements(jval, val, JNI_ABORT);
+
+  if (!s.ok()) {
+    rocksdb::RocksDBExceptionJni::ThrowNew(env, s);
+  }
+}
+
+/*
+ * Class:     org_rocksdb_CassandraPartitionMetaData
  * Method:    enableBloomFilter
  * Signature: (JI)V
  */

--- a/java/rocksjni/cassandra_partition_meta_datajni.cc
+++ b/java/rocksjni/cassandra_partition_meta_datajni.cc
@@ -1,0 +1,67 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include <jni.h>
+#include "include/org_rocksdb_CassandraPartitionMetaData.h"
+#include "rocksjni/portal.h"
+#include "utilities/cassandra/partition_meta_data.h"
+
+/*
+ * Class:     org_rocksdb_CassandraPartitionMetaData
+ * Method:    createCassandraPartitionMetaData0
+ * Signature: (JJI)J
+ */
+JNIEXPORT jlong JNICALL
+Java_org_rocksdb_CassandraPartitionMetaData_createCassandraPartitionMetaData0(
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong db_pointer,
+    jlong meta_cf_hande_pointer, jint token_length) {
+  auto* db = reinterpret_cast<rocksdb::DB*>(db_pointer);
+  auto* meta_cf_handle =
+      reinterpret_cast<rocksdb::ColumnFamilyHandle*>(meta_cf_hande_pointer);
+  auto* meta_data = new rocksdb::cassandra::PartitionMetaData(
+      db, meta_cf_handle, token_length);
+  return reinterpret_cast<jlong>(meta_data);
+}
+
+/*
+ * Class:     org_rocksdb_CassandraPartitionMetaData
+ * Method:    disposeInternal
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL
+Java_org_rocksdb_CassandraPartitionMetaData_disposeInternal(
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong meta_data_pointer) {
+  delete reinterpret_cast<rocksdb::cassandra::PartitionMetaData*>(
+      meta_data_pointer);
+}
+
+/*
+ * Class:     org_rocksdb_CassandraPartitionMetaData
+ * Method:    deletePartition
+ * Signature: (J[BIJ)V
+ */
+JNIEXPORT void JNICALL
+Java_org_rocksdb_CassandraPartitionMetaData_deletePartition(
+    JNIEnv* env, jobject /*jobj*/, jlong meta_data_pointer,
+    jbyteArray partition_key_with_token, jint local_deletion_time,
+    jlong marked_for_delete_at) {
+  jbyte* key = env->GetByteArrayElements(partition_key_with_token, nullptr);
+  if (key == nullptr) {
+    // exception thrown: OutOfMemoryError
+    return;
+  }
+  rocksdb::Slice key_slice(reinterpret_cast<char*>(key),
+                           env->GetArrayLength(partition_key_with_token));
+  auto* meta_data = reinterpret_cast<rocksdb::cassandra::PartitionMetaData*>(
+      meta_data_pointer);
+  rocksdb::Status s = meta_data->DeletePartition(key_slice, local_deletion_time,
+                                                 marked_for_delete_at);
+
+  env->ReleaseByteArrayElements(partition_key_with_token, key, JNI_ABORT);
+
+  if (!s.ok()) {
+    rocksdb::RocksDBExceptionJni::ThrowNew(env, s);
+  }
+}

--- a/java/rocksjni/cassandra_partition_meta_datajni.cc
+++ b/java/rocksjni/cassandra_partition_meta_datajni.cc
@@ -65,3 +65,20 @@ Java_org_rocksdb_CassandraPartitionMetaData_deletePartition(
     rocksdb::RocksDBExceptionJni::ThrowNew(env, s);
   }
 }
+
+/*
+ * Class:     org_rocksdb_CassandraPartitionMetaData
+ * Method:    enableBloomFilter
+ * Signature: (JI)V
+ */
+JNIEXPORT void JNICALL
+Java_org_rocksdb_CassandraPartitionMetaData_enableBloomFilter(
+    JNIEnv* env, jobject /*jobj*/, jlong meta_data_pointer,
+    jint bloom_total_bits) {
+  auto* meta_data = reinterpret_cast<rocksdb::cassandra::PartitionMetaData*>(
+      meta_data_pointer);
+  rocksdb::Status s = meta_data->EnableBloomFilter((uint32_t)bloom_total_bits);
+  if (!s.ok()) {
+    rocksdb::RocksDBExceptionJni::ThrowNew(env, s);
+  }
+}

--- a/java/rocksjni/ingest_external_file_options.cc
+++ b/java/rocksjni/ingest_external_file_options.cc
@@ -141,6 +141,33 @@ void Java_org_rocksdb_IngestExternalFileOptions_setAllowBlockingFlush(
 
 /*
  * Class:     org_rocksdb_IngestExternalFileOptions
+ * Method:    ingestBehind
+ * Signature: (J)Z
+ */
+JNIEXPORT jboolean JNICALL
+Java_org_rocksdb_IngestExternalFileOptions_ingestBehind(JNIEnv* /*env*/,
+                                                        jobject /*obj*/,
+                                                        jlong jhandle) {
+  auto* options =
+      reinterpret_cast<rocksdb::IngestExternalFileOptions*>(jhandle);
+  return static_cast<jboolean>(options->ingest_behind);
+}
+
+/*
+ * Class:     org_rocksdb_IngestExternalFileOptions
+ * Method:    setIngestBehind
+ * Signature: (JZ)V
+ */
+JNIEXPORT void JNICALL
+Java_org_rocksdb_IngestExternalFileOptions_setIngestBehind(
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jboolean jingest_behind) {
+  auto* options =
+      reinterpret_cast<rocksdb::IngestExternalFileOptions*>(jhandle);
+  options->ingest_behind = static_cast<bool>(jingest_behind);
+}
+
+/*
+ * Class:     org_rocksdb_IngestExternalFileOptions
  * Method:    disposeInternal
  * Signature: (J)V
  */

--- a/java/rocksjni/options.cc
+++ b/java/rocksjni/options.cc
@@ -6026,6 +6026,29 @@ jboolean Java_org_rocksdb_DBOptions_avoidFlushDuringShutdown(JNIEnv* /*env*/,
   return static_cast<jboolean>(opt->avoid_flush_during_shutdown);
 }
 
+/*
+ * Class:     org_rocksdb_DBOptions
+ * Method:    allowIngestBehind
+ * Signature: (J)Z
+ */
+JNIEXPORT jboolean JNICALL Java_org_rocksd_DBOptions_allowIngestBehind(
+    JNIEnv* /*env*/, jobject /*obj*/, jlong jhandle) {
+  auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
+  return static_cast<bool>(opt->allow_ingest_behind);
+}
+
+/*
+ * Class:     org_rocksdb_DBOptions
+ * Method:    setAllowIngestBehind
+ * Signature: (JZ)V
+ */
+JNIEXPORT void JNICALL Java_org_rocksdb_DBOptions_setAllowIngestBehind(
+    JNIEnv* /*env*/, jobject /*obj*/, jlong jhandle,
+    jboolean jallow_ingest_behind) {
+  auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
+  opt->allow_ingest_behind = static_cast<bool>(jallow_ingest_behind);
+}
+
 //////////////////////////////////////////////////////////////////////////////
 // rocksdb::WriteOptions
 

--- a/java/rocksjni/rocksjni.cc
+++ b/java/rocksjni/rocksjni.cc
@@ -1318,9 +1318,9 @@ void Java_org_rocksdb_RocksDB_deleteRange__J_3BII_3BII(
  * Signature: (J[BII[BII)V
  */
 JNIEXPORT void JNICALL Java_org_rocksdb_RocksDB_deleteFilesInRange(
-  JNIEnv* env, jobject /*jdb*/, jlong jdb_handle, jbyteArray jbegin_key,
-  jint jbegin_key_off, jint jbegin_key_len, jbyteArray jend_key,
-  jint jend_key_off, jint jend_key_len) {
+    JNIEnv* env, jobject /*jdb*/, jlong jdb_handle, jbyteArray jbegin_key,
+    jint jbegin_key_off, jint jbegin_key_len, jbyteArray jend_key,
+    jint jend_key_off, jint jend_key_len) {
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
   auto* cf_handle = db->DefaultColumnFamily();
 

--- a/java/src/main/java/org/rocksdb/CassandraCompactionFilter.java
+++ b/java/src/main/java/org/rocksdb/CassandraCompactionFilter.java
@@ -10,16 +10,10 @@ package org.rocksdb;
  */
 public class CassandraCompactionFilter
     extends AbstractCompactionFilter<Slice> {
-  public CassandraCompactionFilter(
-      boolean purgeTtlOnExpiration, boolean ignoreRangeDeleteOnRead, int gcGracePeriodInSeconds) {
-    super(createNewCassandraCompactionFilter0(
-        purgeTtlOnExpiration, ignoreRangeDeleteOnRead, gcGracePeriodInSeconds, 0));
-  }
-
   public CassandraCompactionFilter(boolean purgeTtlOnExpiration, boolean ignoreRangeDeleteOnRead,
-      int gcGracePeriodInSeconds, int partitionKeyLength) {
+      int gcGracePeriodInSeconds, int tokenLength) {
     super(createNewCassandraCompactionFilter0(
-        purgeTtlOnExpiration, ignoreRangeDeleteOnRead, gcGracePeriodInSeconds, partitionKeyLength));
+        purgeTtlOnExpiration, ignoreRangeDeleteOnRead, gcGracePeriodInSeconds, tokenLength));
   }
 
   public void setMetaCfHandle(RocksDB rocksdb, ColumnFamilyHandle metaCfHandle) {
@@ -27,7 +21,7 @@ public class CassandraCompactionFilter
   }
 
   private native static long createNewCassandraCompactionFilter0(boolean purgeTtlOnExpiration,
-      boolean ignoreRangeDeleteOnRead, int gcGracePeriodInSeconds, int partitionKeyLength);
+      boolean ignoreRangeDeleteOnRead, int gcGracePeriodInSeconds, int tokenLength);
 
   private native static void setMetaCfHandle(
       long compactionFilter, long rocksdb, long metaCfHandle);

--- a/java/src/main/java/org/rocksdb/CassandraCompactionFilter.java
+++ b/java/src/main/java/org/rocksdb/CassandraCompactionFilter.java
@@ -10,19 +10,18 @@ package org.rocksdb;
  */
 public class CassandraCompactionFilter
     extends AbstractCompactionFilter<Slice> {
-  public CassandraCompactionFilter(boolean purgeTtlOnExpiration, boolean ignoreRangeDeleteOnRead,
-      int gcGracePeriodInSeconds, int tokenLength) {
+  public CassandraCompactionFilter(
+      boolean purgeTtlOnExpiration, boolean ignoreRangeDeleteOnRead, int gcGracePeriodInSeconds) {
     super(createNewCassandraCompactionFilter0(
-        purgeTtlOnExpiration, ignoreRangeDeleteOnRead, gcGracePeriodInSeconds, tokenLength));
+        purgeTtlOnExpiration, ignoreRangeDeleteOnRead, gcGracePeriodInSeconds));
   }
 
-  public void setMetaCfHandle(RocksDB rocksdb, ColumnFamilyHandle metaCfHandle) {
-    setMetaCfHandle(getNativeHandle(), rocksdb.getNativeHandle(), metaCfHandle.getNativeHandle());
+  public void setPartitionMetaData(CassandraPartitionMetaData partitionMetaData) {
+    setPartitionMetaData(getNativeHandle(), partitionMetaData.getNativeHandle());
   }
 
-  private native static long createNewCassandraCompactionFilter0(boolean purgeTtlOnExpiration,
-      boolean ignoreRangeDeleteOnRead, int gcGracePeriodInSeconds, int tokenLength);
+  private native static long createNewCassandraCompactionFilter0(
+      boolean purgeTtlOnExpiration, boolean ignoreRangeDeleteOnRead, int gcGracePeriodInSeconds);
 
-  private native static void setMetaCfHandle(
-      long compactionFilter, long rocksdb, long metaCfHandle);
+  private native static void setPartitionMetaData(long compactionFilter, long partitionMetaData);
 }

--- a/java/src/main/java/org/rocksdb/CassandraPartitionMetaData.java
+++ b/java/src/main/java/org/rocksdb/CassandraPartitionMetaData.java
@@ -24,6 +24,11 @@ public class CassandraPartitionMetaData extends RocksObject {
     deletePartition(getNativeHandle(), partitonKeyWithToken, localDeletionTime, markedForDeleteAt);
   }
 
+  // store raw partition meta data for streaming case
+  public void applyRaw(final byte[] key, final byte[] value) throws RocksDBException {
+    applyRaw(getNativeHandle(), key, value);
+  }
+
   private native static long createCassandraPartitionMetaData0(
       long rocksdb, long metaCfHandle, int tokenLength);
 
@@ -31,6 +36,8 @@ public class CassandraPartitionMetaData extends RocksObject {
 
   protected native void deletePartition(long handle, byte[] partitonKeyWithToken,
       int localDeletionTime, long markedForDeleteAt) throws RocksDBException;
+
+  protected native void applyRaw(long handle, byte[] key, byte[] value) throws RocksDBException;
 
   protected native void enableBloomFilter(long handle, int bloomTotalBits) throws RocksDBException;
 }

--- a/java/src/main/java/org/rocksdb/CassandraPartitionMetaData.java
+++ b/java/src/main/java/org/rocksdb/CassandraPartitionMetaData.java
@@ -15,6 +15,10 @@ public class CassandraPartitionMetaData extends RocksObject {
         rocksdb.getNativeHandle(), metaCfHandle.getNativeHandle(), tokenLength));
   }
 
+  public void enableBloomFilter(int bloomTotalBits) throws RocksDBException {
+    enableBloomFilter(getNativeHandle(), bloomTotalBits);
+  }
+
   public void deletePartition(final byte[] partitonKeyWithToken, int localDeletionTime,
       long markedForDeleteAt) throws RocksDBException {
     deletePartition(getNativeHandle(), partitonKeyWithToken, localDeletionTime, markedForDeleteAt);
@@ -27,4 +31,6 @@ public class CassandraPartitionMetaData extends RocksObject {
 
   protected native void deletePartition(long handle, byte[] partitonKeyWithToken,
       int localDeletionTime, long markedForDeleteAt) throws RocksDBException;
+
+  protected native void enableBloomFilter(long handle, int bloomTotalBits) throws RocksDBException;
 }

--- a/java/src/main/java/org/rocksdb/CassandraPartitionMetaData.java
+++ b/java/src/main/java/org/rocksdb/CassandraPartitionMetaData.java
@@ -1,0 +1,30 @@
+//  Copyright (c) 2017-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+package org.rocksdb;
+
+/**
+ * Java wrapper for PartitionMetaData implemented in C++
+ */
+public class CassandraPartitionMetaData extends RocksObject {
+  public CassandraPartitionMetaData(
+      RocksDB rocksdb, ColumnFamilyHandle metaCfHandle, int tokenLength) {
+    super(createCassandraPartitionMetaData0(
+        rocksdb.getNativeHandle(), metaCfHandle.getNativeHandle(), tokenLength));
+  }
+
+  public void deletePartition(final byte[] partitonKeyWithToken, int localDeletionTime,
+      long markedForDeleteAt) throws RocksDBException {
+    deletePartition(getNativeHandle(), partitonKeyWithToken, localDeletionTime, markedForDeleteAt);
+  }
+
+  private native static long createCassandraPartitionMetaData0(
+      long rocksdb, long metaCfHandle, int tokenLength);
+
+  @Override protected final native void disposeInternal(final long handle);
+
+  protected native void deletePartition(long handle, byte[] partitonKeyWithToken,
+      int localDeletionTime, long markedForDeleteAt) throws RocksDBException;
+}

--- a/java/src/main/java/org/rocksdb/DBOptions.java
+++ b/java/src/main/java/org/rocksdb/DBOptions.java
@@ -958,6 +958,17 @@ public class DBOptions
     return avoidFlushDuringShutdown(nativeHandle_);
   }
 
+  public DBOptions setAllowIngestBehind(boolean allowIngestBehind) {
+    assert (isOwningHandle());
+    setAllowIngestBehind(nativeHandle_, allowIngestBehind);
+    return this;
+  }
+
+  public boolean allowIngestBehind() {
+    assert (isOwningHandle());
+    return allowIngestBehind(nativeHandle_);
+  }
+
   static final int DEFAULT_NUM_SHARD_BITS = -1;
 
 
@@ -1151,6 +1162,8 @@ public class DBOptions
   private native void setAvoidFlushDuringShutdown(final long handle,
       final boolean avoidFlushDuringShutdown);
   private native boolean avoidFlushDuringShutdown(final long handle);
+  private native boolean allowIngestBehind(final long handle);
+  private native void setAllowIngestBehind(final long handle, boolean allowIngestBehind);
 
   // instance variables
   // NOTE: If you add new member variables, please update the copy constructor above!

--- a/java/src/main/java/org/rocksdb/IngestExternalFileOptions.java
+++ b/java/src/main/java/org/rocksdb/IngestExternalFileOptions.java
@@ -106,6 +106,14 @@ public class IngestExternalFileOptions extends RocksObject {
     setAllowBlockingFlush(nativeHandle_, allowBlockingFlush);
   }
 
+  public boolean ingestBehind() {
+    return ingestBehind(nativeHandle_);
+  }
+
+  public void setIngestBehind(final boolean ingestBehind) {
+    setIngestBehind(nativeHandle_, ingestBehind);
+  }
+
   private native static long newIngestExternalFileOptions();
   private native static long newIngestExternalFileOptions(
       final boolean moveFiles, final boolean snapshotConsistency,
@@ -121,5 +129,7 @@ public class IngestExternalFileOptions extends RocksObject {
   private native boolean allowBlockingFlush(final long handle);
   private native void setAllowBlockingFlush(final long handle,
       final boolean allowBlockingFlush);
+  private native boolean ingestBehind(final long handle);
+  private native void setIngestBehind(final long handle, final boolean ingestBehind);
   @Override protected final native void disposeInternal(final long handle);
 }

--- a/src.mk
+++ b/src.mk
@@ -164,6 +164,7 @@ LIB_SOURCES =                                                   \
   utilities/blob_db/blob_log_writer.cc                          \
   utilities/blob_db/ttl_extractor.cc                            \
   utilities/cassandra/cassandra_compaction_filter.cc            \
+  utilities/cassandra/partition_meta_data.cc                    \
   utilities/cassandra/format.cc                                 \
   utilities/cassandra/merge_operator.cc                         \
   utilities/checkpoint/checkpoint_impl.cc                       \
@@ -353,6 +354,7 @@ MAIN_SOURCES =                                                          \
   utilities/blob_db/blob_db_test.cc                                     \
   utilities/cassandra/cassandra_format_test.cc                          \
   utilities/cassandra/cassandra_functional_test.cc                      \
+  utilities/cassandra/cassandra_partition_meta_data_test.cc             \
   utilities/cassandra/cassandra_row_merge_test.cc                       \
   utilities/cassandra/cassandra_serialize_test.cc                       \
   utilities/checkpoint/checkpoint_test.cc                               \

--- a/src.mk
+++ b/src.mk
@@ -413,6 +413,7 @@ JNI_NATIVE_SOURCES =                                          \
   java/rocksjni/remove_emptyvalue_compactionfilterjni.cc      \
   java/rocksjni/cassandra_compactionfilterjni.cc              \
   java/rocksjni/cassandra_value_operator.cc                   \
+  java/rocksjni/cassandra_partition_meta_datajni.cc           \
   java/rocksjni/cassandra_partition_meta_merge_operator.cc    \
   java/rocksjni/restorejni.cc                                 \
   java/rocksjni/rocks_callback_object.cc                      \

--- a/utilities/cassandra/cassandra_compaction_filter.cc
+++ b/utilities/cassandra/cassandra_compaction_filter.cc
@@ -18,27 +18,27 @@ void CassandraCompactionFilter::SetMetaCfHandle(
   meta_cf_handle_ = meta_cf_handle;
 }
 
-std::shared_ptr<PartitionDeletion>
+std::unique_ptr<PartitionDeletion>
 CassandraCompactionFilter::GetPartitionDelete(const Slice& key) const {
   if (!meta_db_) {
     // skip triming when parition meta db is not ready yet
-    return PartitionDeletion::kDefault;
+    return nullptr;
   }
 
   DB* meta_db = meta_db_.load();
   if (!meta_cf_handle_) {
     // skip triming when parition meta cf handle is not ready yet
-    return PartitionDeletion::kDefault;
+    return nullptr;
   }
   ColumnFamilyHandle* meta_cf_handle = meta_cf_handle_.load();
   return GetPartitionDeleteByPointQuery(key, meta_db, meta_cf_handle);
 }
 
-std::shared_ptr<PartitionDeletion>
+std::unique_ptr<PartitionDeletion>
 CassandraCompactionFilter::GetPartitionDeleteByPointQuery(
     const Slice& key, DB* meta_db, ColumnFamilyHandle* meta_cf) const {
   if (key.size() < token_length_) {
-    return PartitionDeletion::kDefault;
+    return nullptr;
   }
 
   Slice token(key.data(), token_length_);
@@ -50,11 +50,11 @@ CassandraCompactionFilter::GetPartitionDeleteByPointQuery(
         PartitionDeletion::Deserialize(val.data(), val.size());
     for (auto& pd : pds) {
       if (key_wo_token.starts_with(pd->PartitionKey())) {
-        return pd;
+        return std::move(pd);
       }
     }
   }
-  return PartitionDeletion::kDefault;
+  return nullptr;
 }
 
 bool CassandraCompactionFilter::ShouldDropByParitionDelete(
@@ -62,8 +62,10 @@ bool CassandraCompactionFilter::ShouldDropByParitionDelete(
     std::chrono::time_point<std::chrono::system_clock> row_timestamp) const {
   std::chrono::seconds gc_grace_period =
       ignore_range_delete_on_read_ ? std::chrono::seconds(0) : gc_grace_period_;
-  return GetPartitionDelete(key)->MarkForDeleteAt() >
-         row_timestamp + gc_grace_period;
+  auto pd = GetPartitionDelete(key);
+
+  return pd != nullptr &&
+         pd->MarkForDeleteAt() > row_timestamp + gc_grace_period;
 }
 
 CompactionFilter::Decision CassandraCompactionFilter::FilterV2(

--- a/utilities/cassandra/cassandra_compaction_filter.cc
+++ b/utilities/cassandra/cassandra_compaction_filter.cc
@@ -27,8 +27,8 @@ bool CassandraCompactionFilter::ShouldDropByParitionDelete(
 
   std::chrono::seconds gc_grace_period =
       ignore_range_delete_on_read_ ? std::chrono::seconds(0) : gc_grace_period_;
-  auto meta_data = partition_meta_data_.load();
-  auto deletion_time = meta_data->GetDeletionTime(key);
+  PartitionMetaData* meta_data = partition_meta_data_.load();
+  DeletionTime deletion_time = meta_data->GetDeletionTime(key);
   return deletion_time.MarkForDeleteAt() > row_timestamp + gc_grace_period;
 }
 

--- a/utilities/cassandra/cassandra_compaction_filter.cc
+++ b/utilities/cassandra/cassandra_compaction_filter.cc
@@ -28,10 +28,8 @@ bool CassandraCompactionFilter::ShouldDropByParitionDelete(
   std::chrono::seconds gc_grace_period =
       ignore_range_delete_on_read_ ? std::chrono::seconds(0) : gc_grace_period_;
   auto meta_data = partition_meta_data_.load();
-  auto pd = meta_data->GetPartitionDelete(key);
-
-  return pd != nullptr &&
-         pd->MarkForDeleteAt() > row_timestamp + gc_grace_period;
+  auto deletion_time = meta_data->GetDeletionTime(key);
+  return deletion_time.MarkForDeleteAt() > row_timestamp + gc_grace_period;
 }
 
 CompactionFilter::Decision CassandraCompactionFilter::FilterV2(

--- a/utilities/cassandra/cassandra_compaction_filter.cc
+++ b/utilities/cassandra/cassandra_compaction_filter.cc
@@ -12,10 +12,9 @@ const char* CassandraCompactionFilter::Name() const {
   return "CassandraCompactionFilter";
 }
 
-void CassandraCompactionFilter::SetMetaCfHandle(
-    DB* meta_db, ColumnFamilyHandle* meta_cf_handle) {
-  partition_meta_data_ =
-      new PartitionMetaData(meta_db, meta_cf_handle, token_length_);
+void CassandraCompactionFilter::SetPartitionMetaData(
+    PartitionMetaData* meta_data) {
+  partition_meta_data_ = meta_data;
 }
 
 bool CassandraCompactionFilter::ShouldDropByParitionDelete(

--- a/utilities/cassandra/cassandra_compaction_filter.h
+++ b/utilities/cassandra/cassandra_compaction_filter.h
@@ -59,10 +59,10 @@ private:
   std::atomic<ColumnFamilyHandle*> meta_cf_handle_;
   std::atomic<DB*> meta_db_;
   ReadOptions meta_read_options_;
-  std::shared_ptr<PartitionDeletion> GetPartitionDelete(const Slice& key) const;
-  std::shared_ptr<PartitionDeletion> GetPartitionDeleteByScan(
+  std::unique_ptr<PartitionDeletion> GetPartitionDelete(const Slice& key) const;
+  std::unique_ptr<PartitionDeletion> GetPartitionDeleteByScan(
       const Slice& key, DB* meta_db, ColumnFamilyHandle* meta_cf) const;
-  std::shared_ptr<PartitionDeletion> GetPartitionDeleteByPointQuery(
+  std::unique_ptr<PartitionDeletion> GetPartitionDeleteByPointQuery(
       const Slice& key, DB* meta_db, ColumnFamilyHandle* meta_cf) const;
   bool ShouldDropByParitionDelete(
       const Slice& key,

--- a/utilities/cassandra/cassandra_compaction_filter.h
+++ b/utilities/cassandra/cassandra_compaction_filter.h
@@ -34,33 +34,22 @@ class CassandraCompactionFilter : public CompactionFilter {
 public:
  explicit CassandraCompactionFilter(bool purge_ttl_on_expiration,
                                     bool ignore_range_delete_on_read,
-                                    int32_t gc_grace_period_in_seconds,
-                                    size_t token_length)
+                                    int32_t gc_grace_period_in_seconds)
      : purge_ttl_on_expiration_(purge_ttl_on_expiration),
        ignore_range_delete_on_read_(ignore_range_delete_on_read),
-       gc_grace_period_(gc_grace_period_in_seconds),
-       token_length_(token_length) {}
-
- ~CassandraCompactionFilter() {
-   if (partition_meta_data_) {
-     delete partition_meta_data_.load();
-     partition_meta_data_.exchange(nullptr);
-   }
- }
+       gc_grace_period_(gc_grace_period_in_seconds) {}
 
  const char* Name() const override;
  virtual Decision FilterV2(int level, const Slice& key, ValueType value_type,
                            const Slice& existing_value, std::string* new_value,
                            std::string* skip_until) const override;
-
- void SetMetaCfHandle(DB* meta_db, ColumnFamilyHandle* meta_cf_handle);
+ void SetPartitionMetaData(PartitionMetaData* meta_data);
 
 private:
   bool purge_ttl_on_expiration_;
   bool ignore_range_delete_on_read_;
   std::chrono::seconds gc_grace_period_;
   std::atomic<PartitionMetaData*> partition_meta_data_;
-  size_t token_length_;
   bool ShouldDropByParitionDelete(
       const Slice& key,
       std::chrono::time_point<std::chrono::system_clock> row_timestamp) const;

--- a/utilities/cassandra/cassandra_compaction_filter.h
+++ b/utilities/cassandra/cassandra_compaction_filter.h
@@ -37,7 +37,8 @@ public:
                                     int32_t gc_grace_period_in_seconds)
      : purge_ttl_on_expiration_(purge_ttl_on_expiration),
        ignore_range_delete_on_read_(ignore_range_delete_on_read),
-       gc_grace_period_(gc_grace_period_in_seconds) {}
+       gc_grace_period_(gc_grace_period_in_seconds),
+       partition_meta_data_(nullptr) {}
 
  const char* Name() const override;
  virtual Decision FilterV2(int level, const Slice& key, ValueType value_type,

--- a/utilities/cassandra/cassandra_compaction_filter.h
+++ b/utilities/cassandra/cassandra_compaction_filter.h
@@ -34,11 +34,11 @@ public:
  explicit CassandraCompactionFilter(bool purge_ttl_on_expiration,
                                     bool ignore_range_delete_on_read,
                                     int32_t gc_grace_period_in_seconds,
-                                    size_t partition_key_length = 0)
+                                    size_t token_length)
      : purge_ttl_on_expiration_(purge_ttl_on_expiration),
        ignore_range_delete_on_read_(ignore_range_delete_on_read),
        gc_grace_period_(gc_grace_period_in_seconds),
-       partition_key_length_(partition_key_length),
+       token_length_(token_length),
        meta_cf_handle_(nullptr),
        meta_db_(nullptr) {
    meta_read_options_.ignore_range_deletions = true;
@@ -55,14 +55,14 @@ private:
   bool purge_ttl_on_expiration_;
   bool ignore_range_delete_on_read_;
   std::chrono::seconds gc_grace_period_;
-  size_t partition_key_length_;
+  size_t token_length_;
   std::atomic<ColumnFamilyHandle*> meta_cf_handle_;
   std::atomic<DB*> meta_db_;
   ReadOptions meta_read_options_;
-  PartitionDeletion GetPartitionDelete(const Slice& key) const;
-  PartitionDeletion GetPartitionDeleteByScan(const Slice& key, DB* meta_db,
-                                             ColumnFamilyHandle* meta_cf) const;
-  PartitionDeletion GetPartitionDeleteByPointQuery(
+  std::shared_ptr<PartitionDeletion> GetPartitionDelete(const Slice& key) const;
+  std::shared_ptr<PartitionDeletion> GetPartitionDeleteByScan(
+      const Slice& key, DB* meta_db, ColumnFamilyHandle* meta_cf) const;
+  std::shared_ptr<PartitionDeletion> GetPartitionDeleteByPointQuery(
       const Slice& key, DB* meta_db, ColumnFamilyHandle* meta_cf) const;
   bool ShouldDropByParitionDelete(
       const Slice& key,

--- a/utilities/cassandra/cassandra_format_test.cc
+++ b/utilities/cassandra/cassandra_format_test.cc
@@ -380,7 +380,7 @@ TEST(DeletionTimeTest, Serialization) {
   DeletionTime t(100, 101);
   std::string val;
   t.Serialize(&val);
-  EXPECT_EQ(DeletionTime::Deserialize(val.data(), val.size()), t);
+  EXPECT_EQ(DeletionTime::Deserialize(val.data()), t);
 }
 
 std::unique_ptr<PartitionDeletion> pd_make_unique(

--- a/utilities/cassandra/cassandra_format_test.cc
+++ b/utilities/cassandra/cassandra_format_test.cc
@@ -360,13 +360,21 @@ TEST(RowValueTest, ExpireTtlShouldConvertExpiredColumnsToTombstones) {
   EXPECT_FALSE(changed);
 }
 
+std::unique_ptr<PartitionDeletion> pd_make_unique(
+    const Slice& slice, int32_t local_deletion_time,
+    int64_t marked_for_delete_at) {
+  return std::unique_ptr<PartitionDeletion>(
+      new PartitionDeletion(slice, local_deletion_time, marked_for_delete_at));
+}
+
+std::unique_ptr<PartitionDeletion> pd_make_unique(const PartitionDeletion& pd) {
+  return std::unique_ptr<PartitionDeletion>(new PartitionDeletion(pd));
+}
+
 TEST(ParitionDeletionTest, Supersedes) {
-  std::shared_ptr<PartitionDeletion> pd1 =
-      std::make_shared<PartitionDeletion>(Slice(), 100, 100);
-  std::shared_ptr<PartitionDeletion> pd2 =
-      std::make_shared<PartitionDeletion>(Slice(), 100, 101);
-  std::shared_ptr<PartitionDeletion> pd3 =
-      std::make_shared<PartitionDeletion>(Slice(), 101, 101);
+  auto pd1 = pd_make_unique(Slice(), 100, 100);
+  auto pd2 = pd_make_unique(Slice(), 100, 101);
+  auto pd3 = pd_make_unique(Slice(), 101, 101);
 
   EXPECT_TRUE(pd2->Supersedes(pd1));
   EXPECT_TRUE(pd3->Supersedes(pd2));
@@ -375,7 +383,7 @@ TEST(ParitionDeletionTest, Supersedes) {
 
 void AssertRoundTrip(PartitionDeletions& pds) {
   std::string value;
-  PartitionDeletion::Serialize(pds, &value);
+  PartitionDeletion::Serialize(std::move(pds), &value);
   PartitionDeletions deserialized =
       PartitionDeletion::Deserialize(value.data(), value.size());
   EXPECT_EQ(pds.size(), deserialized.size());
@@ -387,57 +395,59 @@ void AssertRoundTrip(PartitionDeletions& pds) {
 TEST(ParitionDeletionTest, Serialization) {
   PartitionDeletions pds;
   AssertRoundTrip(pds);
-  pds.push_back(std::make_shared<PartitionDeletion>(Slice("a"), 100, 200));
+  pds.push_back(pd_make_unique(Slice("a"), 100, 200));
   AssertRoundTrip(pds);
-  pds.push_back(std::make_shared<PartitionDeletion>(Slice("b"), 0, 0));
+  pds.push_back(pd_make_unique(Slice("b"), 0, 0));
   AssertRoundTrip(pds);
-  pds.push_back(PartitionDeletion::kDefault);
+  pds.push_back(pd_make_unique(Slice("abc"),
+                               std::numeric_limits<int32_t>::max(),
+                               std::numeric_limits<int64_t>::min()));
   AssertRoundTrip(pds);
 }
 
 TEST(ParitionDeletionTest, MergeEmpty) {
-  PartitionDeletions pds;
-  EXPECT_EQ(PartitionDeletions(), PartitionDeletion::Merge(pds));
+  EXPECT_EQ(PartitionDeletions(),
+            PartitionDeletion::Merge(PartitionDeletions()));
 }
 
 TEST(ParitionDeletionTest, MergeSingle) {
-  auto pd0 = std::make_shared<PartitionDeletion>(Slice("a"), 100, 200);
+  PartitionDeletion pd0(Slice("a"), 100, 200);
   PartitionDeletions pds;
-  pds.push_back(pd0);
-  PartitionDeletions merged = PartitionDeletion::Merge(pds);
+  pds.push_back(pd_make_unique(pd0));
+  PartitionDeletions merged = PartitionDeletion::Merge(std::move(pds));
   EXPECT_EQ(1, merged.size());
-  EXPECT_EQ(merged[0], pd0);
+  EXPECT_EQ(pd0, *merged[0]);
 }
 
 TEST(ParitionDeletionTest, MergeSinglePKKeepLast) {
-  auto pd0 = std::make_shared<PartitionDeletion>(Slice("a"), 100, 200);
-  auto pd1 = std::make_shared<PartitionDeletion>(Slice("a"), 101, 300);
-  auto pd2 = std::make_shared<PartitionDeletion>(Slice("a"), 100, 300);
+  PartitionDeletion pd0(Slice("a"), 100, 200);
+  PartitionDeletion pd1(Slice("a"), 101, 300);
+  PartitionDeletion pd2(Slice("a"), 100, 300);
 
   PartitionDeletions pds;
-  pds.push_back(pd0);
-  pds.push_back(pd1);
-  pds.push_back(pd2);
+  pds.push_back(pd_make_unique(pd0));
+  pds.push_back(pd_make_unique(pd1));
+  pds.push_back(pd_make_unique(pd2));
 
-  PartitionDeletions merged = PartitionDeletion::Merge(pds);
+  PartitionDeletions merged = PartitionDeletion::Merge(std::move(pds));
   EXPECT_EQ(1, merged.size());
-  EXPECT_EQ(merged[0], pd1);
+  EXPECT_EQ(pd1, *merged[0]);
 }
 
 TEST(ParitionDeletionTest, MergeKeepLastestDeletionPerPK) {
-  auto pd0 = std::make_shared<PartitionDeletion>(Slice("a"), 100, 200);
-  auto pd1 = std::make_shared<PartitionDeletion>(Slice("b"), 100, 200);
-  auto pd2 = std::make_shared<PartitionDeletion>(Slice("a"), 101, 300);
-  auto pd3 = std::make_shared<PartitionDeletion>(Slice("a"), 100, 300);
+  PartitionDeletion pd0(Slice("a"), 100, 200);
+  PartitionDeletion pd1(Slice("b"), 100, 200);
+  PartitionDeletion pd2(Slice("a"), 101, 300);
+  PartitionDeletion pd3(Slice("a"), 100, 300);
   PartitionDeletions pds;
-  pds.push_back(pd0);
-  pds.push_back(pd1);
-  pds.push_back(pd2);
-  pds.push_back(pd3);
-  PartitionDeletions merged = PartitionDeletion::Merge(pds);
+  pds.push_back(pd_make_unique(pd0));
+  pds.push_back(pd_make_unique(pd1));
+  pds.push_back(pd_make_unique(pd2));
+  pds.push_back(pd_make_unique(pd3));
+  PartitionDeletions merged = PartitionDeletion::Merge(std::move(pds));
   EXPECT_EQ(2, merged.size());
-  EXPECT_EQ(merged[0], pd2);
-  EXPECT_EQ(merged[1], pd1);
+  EXPECT_EQ(pd2, *merged[0]);
+  EXPECT_EQ(pd1, *merged[1]);
 }
 } // namespace cassandra
 } // namespace rocksdb

--- a/utilities/cassandra/cassandra_functional_test.cc
+++ b/utilities/cassandra/cassandra_functional_test.cc
@@ -88,10 +88,10 @@ class CassandraStore {
     Slice partition_key(partition_key_with_token.data() + token_length_,
                         partition_key_with_token.size() - token_length_);
     PartitionDeletions pds;
-    pds.push_back(std::make_shared<PartitionDeletion>(
-        partition_key, local_deletion_time, marked_for_delete_at));
+    pds.push_back(std::unique_ptr<PartitionDeletion>(new PartitionDeletion(
+        partition_key, local_deletion_time, marked_for_delete_at)));
     std::string val;
-    PartitionDeletion::Serialize(pds, &val);
+    PartitionDeletion::Serialize(std::move(pds), &val);
     Slice valslice(val.data(), val.size());
 
     auto s = db_->Merge(write_option_, meta_cf_handle_, token, valslice);

--- a/utilities/cassandra/cassandra_functional_test.cc
+++ b/utilities/cassandra/cassandra_functional_test.cc
@@ -28,10 +28,11 @@ class CassandraStore {
   explicit CassandraStore(bool purge_ttl_on_expiration = false,
                           int32_t gc_grace_period_in_seconds = 100,
                           bool ignore_range_delete_on_read = false,
-                          size_t partition_key_length = 0) {
+                          size_t token_length = 3) {
+    token_length_ = token_length;
     data_compaction_filter_ = new CassandraCompactionFilter(
         purge_ttl_on_expiration, ignore_range_delete_on_read,
-        gc_grace_period_in_seconds, partition_key_length);
+        gc_grace_period_in_seconds, token_length);
     Options options;
     options.create_if_missing = true;
     options.create_missing_column_families = true;
@@ -80,12 +81,20 @@ class CassandraStore {
     }
   }
 
-  bool DeletePartition(const std::string& partition_key,
-                       const PartitionDeletion& deletion) {
+  bool DeletePartition(const std::string& partition_key_with_token,
+                       int32_t local_deletion_time,
+                       int64_t marked_for_delete_at) {
+    Slice token(partition_key_with_token.data(), token_length_);
+    Slice partition_key(partition_key_with_token.data() + token_length_,
+                        partition_key_with_token.size() - token_length_);
+    PartitionDeletions pds;
+    pds.push_back(std::make_shared<PartitionDeletion>(
+        partition_key, local_deletion_time, marked_for_delete_at));
     std::string val;
-    deletion.Serialize(&val);
-    Slice slice(val.data(), val.size());
-    auto s = db_->Merge(write_option_, meta_cf_handle_, partition_key, slice);
+    PartitionDeletion::Serialize(pds, &val);
+    Slice valslice(val.data(), val.size());
+
+    auto s = db_->Merge(write_option_, meta_cf_handle_, token, valslice);
     if (s.ok()) {
       return true;
     } else {
@@ -141,6 +150,7 @@ class CassandraStore {
   ColumnFamilyHandle* meta_cf_handle_;
   WriteOptions write_option_;
   ReadOptions get_option_;
+  size_t token_length_;
 
   DBImpl* dbfull() { return reinterpret_cast<DBImpl*>(db_); }
 };
@@ -161,14 +171,14 @@ TEST_F(CassandraFunctionalTest, SimpleMergeTest) {
   int64_t now = time(nullptr);
 
   store.Append(
-      "k1",
+      "t0-k1",
       CreateTestRowValue({
           CreateTestColumnSpec(kTombstone, 0, ToMicroSeconds(now + 5)),
           CreateTestColumnSpec(kColumn, 1, ToMicroSeconds(now + 8)),
           CreateTestColumnSpec(kExpiringColumn, 2, ToMicroSeconds(now + 5)),
       }));
   store.Append(
-      "k1",
+      "t0-k1",
       CreateTestRowValue({
           CreateTestColumnSpec(kColumn, 0, ToMicroSeconds(now + 2)),
           CreateTestColumnSpec(kExpiringColumn, 1, ToMicroSeconds(now + 5)),
@@ -176,7 +186,7 @@ TEST_F(CassandraFunctionalTest, SimpleMergeTest) {
           CreateTestColumnSpec(kExpiringColumn, 7, ToMicroSeconds(now + 17)),
       }));
   store.Append(
-      "k1",
+      "t0-k1",
       CreateTestRowValue({
           CreateTestColumnSpec(kExpiringColumn, 0, ToMicroSeconds(now + 6)),
           CreateTestColumnSpec(kTombstone, 1, ToMicroSeconds(now + 5)),
@@ -184,7 +194,7 @@ TEST_F(CassandraFunctionalTest, SimpleMergeTest) {
           CreateTestColumnSpec(kTombstone, 11, ToMicroSeconds(now + 11)),
       }));
 
-  auto ret = store.Get("k1");
+  auto ret = store.Get("t0-k1");
 
   ASSERT_TRUE(std::get<0>(ret));
   RowValue& merged = std::get<1>(ret);
@@ -202,7 +212,7 @@ TEST_F(CassandraFunctionalTest,
   int64_t now= time(nullptr);
 
   store.Append(
-      "k1",
+      "t0-k1",
       CreateTestRowValue(
           {CreateTestColumnSpec(kExpiringColumn, 0,
                                 ToMicroSeconds(now - kTtl - 20)),  // expired
@@ -214,7 +224,7 @@ TEST_F(CassandraFunctionalTest,
   store.Flush();
 
   store.Append(
-      "k1",
+      "t0-k1",
       CreateTestRowValue(
           {CreateTestColumnSpec(kExpiringColumn, 0,
                                 ToMicroSeconds(now - kTtl - 10)),  // expired
@@ -223,7 +233,7 @@ TEST_F(CassandraFunctionalTest,
   store.Flush();
   store.Compact();
 
-  auto ret = store.Get("k1");
+  auto ret = store.Get("t0-k1");
   ASSERT_TRUE(std::get<0>(ret));
   RowValue& merged = std::get<1>(ret);
   EXPECT_EQ(merged.columns_.size(), 4);
@@ -240,7 +250,7 @@ TEST_F(CassandraFunctionalTest,
   int64_t now = time(nullptr);
 
   store.Append(
-      "k1",
+      "t0-k1",
       CreateTestRowValue(
           {CreateTestColumnSpec(kExpiringColumn, 0,
                                 ToMicroSeconds(now - kTtl - 20)),  // expired
@@ -251,7 +261,7 @@ TEST_F(CassandraFunctionalTest,
   store.Flush();
 
   store.Append(
-      "k1",
+      "t0-k1",
       CreateTestRowValue(
           {CreateTestColumnSpec(kExpiringColumn, 0,
                                 ToMicroSeconds(now - kTtl - 10)),  // expired
@@ -260,7 +270,7 @@ TEST_F(CassandraFunctionalTest,
   store.Flush();
   store.Compact();
 
-  auto ret = store.Get("k1");
+  auto ret = store.Get("t0-k1");
   ASSERT_TRUE(std::get<0>(ret));
   RowValue& merged = std::get<1>(ret);
   EXPECT_EQ(merged.columns_.size(), 3);
@@ -274,23 +284,25 @@ TEST_F(CassandraFunctionalTest,
   CassandraStore store(true);
   int64_t now = time(nullptr);
 
-  store.Append("k1", CreateTestRowValue({
-                         CreateTestColumnSpec(kExpiringColumn, 0,
-                                              ToMicroSeconds(now - kTtl - 20)),
-                         CreateTestColumnSpec(kExpiringColumn, 1,
-                                              ToMicroSeconds(now - kTtl - 20)),
-                     }));
+  store.Append("t0-k1",
+               CreateTestRowValue({
+                   CreateTestColumnSpec(kExpiringColumn, 0,
+                                        ToMicroSeconds(now - kTtl - 20)),
+                   CreateTestColumnSpec(kExpiringColumn, 1,
+                                        ToMicroSeconds(now - kTtl - 20)),
+               }));
 
   store.Flush();
 
-  store.Append("k1", CreateTestRowValue({
-                         CreateTestColumnSpec(kExpiringColumn, 0,
-                                              ToMicroSeconds(now - kTtl - 10)),
-                     }));
+  store.Append("t0-k1",
+               CreateTestRowValue({
+                   CreateTestColumnSpec(kExpiringColumn, 0,
+                                        ToMicroSeconds(now - kTtl - 10)),
+               }));
 
   store.Flush();
   store.Compact();
-  ASSERT_FALSE(std::get<0>(store.Get("k1")));
+  ASSERT_FALSE(std::get<0>(store.Get("t0-k1")));
 }
 
 TEST_F(CassandraFunctionalTest,
@@ -299,26 +311,27 @@ TEST_F(CassandraFunctionalTest,
   CassandraStore store(true, gc_grace_period_in_seconds);
   int64_t now = time(nullptr);
 
-  store.Append("k1",
+  store.Append("t0-k1",
                CreateTestRowValue(
                    {CreateTestColumnSpec(
                         kTombstone, 0,
                         ToMicroSeconds(now - gc_grace_period_in_seconds - 1)),
                     CreateTestColumnSpec(kColumn, 1, ToMicroSeconds(now))}));
 
-  store.Append("k2", CreateTestRowValue({CreateTestColumnSpec(
-                         kColumn, 0, ToMicroSeconds(now))}));
+  store.Append("t0-k2", CreateTestRowValue({CreateTestColumnSpec(
+                            kColumn, 0, ToMicroSeconds(now))}));
 
   store.Flush();
 
-  store.Append("k1", CreateTestRowValue({
-                         CreateTestColumnSpec(kColumn, 1, ToMicroSeconds(now)),
-                     }));
+  store.Append("t0-k1",
+               CreateTestRowValue({
+                   CreateTestColumnSpec(kColumn, 1, ToMicroSeconds(now)),
+               }));
 
   store.Flush();
   store.Compact();
 
-  auto ret = store.Get("k1");
+  auto ret = store.Get("t0-k1");
   ASSERT_TRUE(std::get<0>(ret));
   RowValue& gced = std::get<1>(ret);
   EXPECT_EQ(gced.columns_.size(), 1);
@@ -330,15 +343,16 @@ TEST_F(CassandraFunctionalTest, CompactionShouldRemoveTombstoneFromPut) {
   CassandraStore store(true, gc_grace_period_in_seconds);
   int64_t now = time(nullptr);
 
-  store.Put("k1", CreateTestRowValue({
-                      CreateTestColumnSpec(
-                          kTombstone, 0,
-                          ToMicroSeconds(now - gc_grace_period_in_seconds - 1)),
-                  }));
+  store.Put("t0-k1",
+            CreateTestRowValue({
+                CreateTestColumnSpec(
+                    kTombstone, 0,
+                    ToMicroSeconds(now - gc_grace_period_in_seconds - 1)),
+            }));
 
   store.Flush();
   store.Compact();
-  ASSERT_FALSE(std::get<0>(store.Get("k1")));
+  ASSERT_FALSE(std::get<0>(store.Get("t0-k1")));
 }
 
 TEST_F(CassandraFunctionalTest, CompactionShouldRemovePartitionDeletedData) {
@@ -347,75 +361,60 @@ TEST_F(CassandraFunctionalTest, CompactionShouldRemovePartitionDeletedData) {
   int64_t now = time(nullptr);
 
   store.Put(
-      "k1",
+      "t0-k1",
       CreateTestRowValue({
           CreateTestColumnSpec(
               kColumn, 0, ToMicroSeconds(now - gc_grace_period_in_seconds - 1)),
       }));
 
-  store.DeletePartition("k",
-                        PartitionDeletion((int32_t)now, ToMicroSeconds(now)));
+  store.DeletePartition("t0-k", (int32_t)now, ToMicroSeconds(now));
   store.Flush();
   store.Compact();
-  ASSERT_FALSE(std::get<0>(store.Get("k1")));
+  ASSERT_FALSE(std::get<0>(store.Get("t0-k1")));
 }
 
-TEST_F(CassandraFunctionalTest, PartitionDeletionWithPointMetaLookup) {
+TEST_F(CassandraFunctionalTest, PartitionDeleteWhenTokenCollision) {
   int gc_grace_period_in_seconds = 100;
-  CassandraStore store(false, gc_grace_period_in_seconds, false, 2);
+  CassandraStore store(false, gc_grace_period_in_seconds);
   int64_t now = time(nullptr);
 
   store.Put(
-      "abcd",
+      "t0-k1",
       CreateTestRowValue({
           CreateTestColumnSpec(
               kColumn, 0, ToMicroSeconds(now - gc_grace_period_in_seconds - 1)),
       }));
-
-  store.DeletePartition("ab",
-                        PartitionDeletion((int32_t)now, ToMicroSeconds(now)));
-  store.Flush();
-  store.Compact();
-  ASSERT_FALSE(std::get<0>(store.Get("abcd")));
-}
-
-TEST_F(CassandraFunctionalTest,
-       PartitionDeletionWithSpecifyBadPartitionLength) {
-  int gc_grace_period_in_seconds = 100;
-  CassandraStore store(false, gc_grace_period_in_seconds, false, 5);
-  int64_t now = time(nullptr);
 
   store.Put(
-      "abcd",
+      "t0-l1",
       CreateTestRowValue({
           CreateTestColumnSpec(
               kColumn, 0, ToMicroSeconds(now - gc_grace_period_in_seconds - 1)),
       }));
 
-  store.DeletePartition("ab",
-                        PartitionDeletion((int32_t)now, ToMicroSeconds(now)));
+  store.DeletePartition("t0-k", (int32_t)now, ToMicroSeconds(now));
   store.Flush();
   store.Compact();
-  ASSERT_TRUE(std::get<0>(store.Get("abcd")));
+  ASSERT_FALSE(std::get<0>(store.Get("t0-k1")));
+  ASSERT_TRUE(std::get<0>(store.Get("t0-l1")));
 }
 
 TEST_F(CassandraFunctionalTest, PartitionDeletionWithNoClusteringKeyCase) {
   int gc_grace_period_in_seconds = 100;
-  CassandraStore store(false, gc_grace_period_in_seconds, false, 4);
+  CassandraStore store(false, gc_grace_period_in_seconds, false);
   int64_t now = time(nullptr);
 
   store.Put(
-      "abcd",
+      "t0-k",
       CreateTestRowValue({
           CreateTestColumnSpec(
               kColumn, 0, ToMicroSeconds(now - gc_grace_period_in_seconds - 1)),
       }));
 
-  store.DeletePartition("abcd",
-                        PartitionDeletion((int32_t)now, ToMicroSeconds(now)));
+  store.DeletePartition("t0-k", (int32_t)now, ToMicroSeconds(now));
   store.Flush();
   store.Compact();
-  ASSERT_FALSE(std::get<0>(store.Get("abcd")));
+  ASSERT_FALSE(std::get<0>(store.Get("t0-k")));
 }
 
 } // namespace cassandra

--- a/utilities/cassandra/cassandra_functional_test.cc
+++ b/utilities/cassandra/cassandra_functional_test.cc
@@ -58,6 +58,7 @@ class CassandraStore {
     data_cf_handle_ = cf_handles.at(0);
     meta_cf_handle_ = cf_handles.at(1);
     meta_data_ = new PartitionMetaData(db_, meta_cf_handle_, token_length);
+    meta_data_->EnableBloomFilter(16 * 8);
     data_compaction_filter_->SetPartitionMetaData(meta_data_);
   }
 

--- a/utilities/cassandra/cassandra_partition_meta_data_test.cc
+++ b/utilities/cassandra/cassandra_partition_meta_data_test.cc
@@ -95,6 +95,20 @@ TEST_F(CassandraPartitionMetaDataTest, ShouldPersistMetaDataCrossDBRestart) {
   EXPECT_EQ(meta_data_->GetDeletionTime("t0-q0-c0-"), DeletionTime(200, 201));
 }
 
+TEST_F(CassandraPartitionMetaDataTest, ShouldGetPartitionMetaStoredByRawApply) {
+  PartitionDeletions pds;
+  std::string val;
+  pds.push_back(std::unique_ptr<PartitionDeletion>(
+      new PartitionDeletion(Slice("p0"), DeletionTime(100, 101))));
+  pds.push_back(std::unique_ptr<PartitionDeletion>(
+      new PartitionDeletion(Slice("q0"), DeletionTime(200, 201))));
+  PartitionDeletion::Serialize(std::move(pds), &val);
+  Status status = meta_data_->ApplyRaw("t0-", val);
+  assert(status.ok());
+  EXPECT_EQ(meta_data_->GetDeletionTime("t0-p0-c0-"), DeletionTime(100, 101));
+  EXPECT_EQ(meta_data_->GetDeletionTime("t0-q0-c0-"), DeletionTime(200, 201));
+}
+
 }  // namespace cassandra
 }  // namespace rocksdb
 

--- a/utilities/cassandra/cassandra_partition_meta_data_test.cc
+++ b/utilities/cassandra/cassandra_partition_meta_data_test.cc
@@ -1,0 +1,103 @@
+// Copyright (c) 2017-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include <memory>
+#include "util/testharness.h"
+#include "utilities/cassandra/merge_operator.h"
+#include "utilities/cassandra/partition_meta_data.h"
+#include "utilities/cassandra/test_utils.h"
+
+namespace rocksdb {
+namespace cassandra {
+// Path to the database on file system
+const size_t kTokenLength = 3;
+const std::string kDbName =
+    test::TmpDir() + "/cassandra_partition_meta_data_test";
+
+// The class for unit-testing
+class CassandraPartitionMetaDataTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    DestroyDB(kDbName, Options());  // Start each test with a fresh DB
+    Options options;
+    options.create_if_missing = true;
+    options.create_missing_column_families = true;
+    ColumnFamilyOptions meta_cf_options;
+    meta_cf_options.merge_operator.reset(
+        new CassandraPartitionMetaMergeOperator());
+
+    std::vector<ColumnFamilyDescriptor> column_families;
+    column_families.emplace_back("default", ColumnFamilyOptions());
+    column_families.emplace_back("meta", meta_cf_options);
+    std::vector<ColumnFamilyHandle*> cf_handles;
+    Status status =
+        DB::Open(options, kDbName, column_families, &cf_handles, &db_);
+    assert(status.ok());
+    assert(cf_handles.size() == 2);
+    data_cf_handle_ = cf_handles.at(0);
+    meta_cf_handle_ = cf_handles.at(1);
+    meta_data_ = new PartitionMetaData(db_, meta_cf_handle_, kTokenLength);
+  }
+
+  void TearDown() override {
+    delete meta_data_;
+    delete data_cf_handle_;
+    delete meta_cf_handle_;
+    delete db_;
+  }
+
+  PartitionMetaData* meta_data_;
+  ColumnFamilyHandle* data_cf_handle_;
+  ColumnFamilyHandle* meta_cf_handle_;
+  DB* db_;
+};
+
+// THE TEST CASES BEGIN HERE
+TEST_F(CassandraPartitionMetaDataTest,
+       GetPartitionDeletionShouldReturnNullForPartitionNotDeleted) {
+  EXPECT_EQ(meta_data_->GetPartitionDelete("t0-p0-c0-"), nullptr);
+  EXPECT_EQ(meta_data_->GetPartitionDelete("t"), nullptr);
+  EXPECT_EQ(meta_data_->GetPartitionDelete(""), nullptr);
+}
+
+TEST_F(CassandraPartitionMetaDataTest,
+       GetPartitionDeletetionShouldReturnDeletedPartition) {
+  meta_data_->DeletePartition("t0-p0", 100, 101);
+  auto pd = meta_data_->GetPartitionDelete("t0-p0-c0-");
+  EXPECT_EQ(pd->LocalDeletionTime(), TimePointFromSeconds(100));
+  EXPECT_EQ(pd->MarkForDeleteAt(), TimePointFromMicroSeconds(101));
+  EXPECT_EQ(pd->PartitionKey(), "p0");
+}
+
+TEST_F(CassandraPartitionMetaDataTest,
+       GetPartitionDeletetionShouldReturnDeletedPartitionInTokenCollisionCase) {
+  meta_data_->DeletePartition("t0-p0", 100, 101);
+  meta_data_->DeletePartition("t0-q0", 200, 201);
+
+  auto pd0 = meta_data_->GetPartitionDelete("t0-p0-c0-");
+  EXPECT_EQ(pd0->LocalDeletionTime(), TimePointFromSeconds(100));
+  EXPECT_EQ(pd0->MarkForDeleteAt(), TimePointFromMicroSeconds(101));
+  EXPECT_EQ(pd0->PartitionKey(), "p0");
+
+  auto pd1 = meta_data_->GetPartitionDelete("t0-q0-c0-");
+  EXPECT_EQ(pd1->LocalDeletionTime(), TimePointFromSeconds(200));
+  EXPECT_EQ(pd1->MarkForDeleteAt(), TimePointFromMicroSeconds(201));
+  EXPECT_EQ(pd1->PartitionKey(), "q0");
+
+  auto pd2 = meta_data_->GetPartitionDelete("t0-q0");
+  EXPECT_EQ(pd2->LocalDeletionTime(), TimePointFromSeconds(200));
+  EXPECT_EQ(pd2->MarkForDeleteAt(), TimePointFromMicroSeconds(201));
+  EXPECT_EQ(pd2->PartitionKey(), "q0");
+
+  EXPECT_EQ(meta_data_->GetPartitionDelete("t0-q"), nullptr);
+}
+
+}  // namespace cassandra
+}  // namespace rocksdb
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/utilities/cassandra/format.cc
+++ b/utilities/cassandra/format.cc
@@ -395,9 +395,7 @@ void DeletionTime::Serialize(std::string* dest) const {
   rocksdb::cassandra::Serialize<int64_t>(marked_for_delete_at_, dest);
 }
 
-const DeletionTime DeletionTime::Deserialize(const char* src,
-                                             std::size_t size) {
-  assert(size >= kSize);
+const DeletionTime DeletionTime::Deserialize(const char* src) {
   int32_t local_deletion_time =
       rocksdb::cassandra::Deserialize<int32_t>(src, 0);
   int64_t marked_for_delete_at =
@@ -433,8 +431,7 @@ PartitionDeletions PartitionDeletion::Deserialize(const char* src,
     offset += pk_length;
 
     if ((size - offset) < DeletionTime::kSize) break;
-    DeletionTime deletion_time =
-        DeletionTime::Deserialize(src + offset, size - offset);
+    DeletionTime deletion_time = DeletionTime::Deserialize(src + offset);
     offset += DeletionTime::kSize;
 
     std::unique_ptr<PartitionDeletion> pd(

--- a/utilities/cassandra/format.h
+++ b/utilities/cassandra/format.h
@@ -203,6 +203,10 @@ class DeletionTime {
       : local_deletion_time_(local_deletion_time),
         marked_for_delete_at_(marked_for_delete_at) {}
 
+  DeletionTime(const DeletionTime& other)
+      : local_deletion_time_(other.local_deletion_time_),
+        marked_for_delete_at_(other.marked_for_delete_at_) {}
+
   std::chrono::time_point<std::chrono::system_clock> MarkForDeleteAt() const {
     return std::chrono::time_point<std::chrono::system_clock>(
         std::chrono::microseconds(marked_for_delete_at_));
@@ -220,7 +224,7 @@ class DeletionTime {
   }
 
   void Serialize(std::string* dest) const;
-  static const DeletionTime Deserialize(const char* src, std::size_t size);
+  static const DeletionTime Deserialize(const char* src);
   const static size_t kSize;
   const static DeletionTime kLive;
 

--- a/utilities/cassandra/format.h
+++ b/utilities/cassandra/format.h
@@ -196,7 +196,7 @@ private:
 };
 
 class PartitionDeletion;
-typedef std::vector<std::shared_ptr<PartitionDeletion>> PartitionDeletions;
+typedef std::vector<std::unique_ptr<PartitionDeletion>> PartitionDeletions;
 
 class PartitionDeletion {
   friend bool operator==(const PartitionDeletion&, const PartitionDeletion&);
@@ -204,14 +204,15 @@ class PartitionDeletion {
  public:
   PartitionDeletion(const Slice& partition_key, int32_t local_deletion_time,
                     int64_t marked_for_delete_at);
+  PartitionDeletion(const PartitionDeletion& pd);
+
   std::chrono::time_point<std::chrono::system_clock> MarkForDeleteAt() const;
   std::chrono::time_point<std::chrono::system_clock> LocalDeletionTime() const;
   const Slice PartitionKey() const;
-  bool Supersedes(std::shared_ptr<PartitionDeletion>& pd) const;
-  static PartitionDeletions Merge(PartitionDeletions& pds);
+  bool Supersedes(std::unique_ptr<PartitionDeletion>& pd) const;
+  static PartitionDeletions Merge(PartitionDeletions&& pds);
   static PartitionDeletions Deserialize(const char* src, std::size_t size);
-  static void Serialize(PartitionDeletions& pds, std::string* dest);
-  const static std::shared_ptr<PartitionDeletion> kDefault;
+  static void Serialize(PartitionDeletions&& pds, std::string* dest);
   const static std::size_t kMinSize;
 
  private:

--- a/utilities/cassandra/format.h
+++ b/utilities/cassandra/format.h
@@ -195,36 +195,73 @@ private:
               CompactionShouldRemoveTombstoneExceedingGCGracePeriod);
 };
 
-class PartitionDeletion;
-typedef std::vector<std::unique_ptr<PartitionDeletion>> PartitionDeletions;
-
-class PartitionDeletion {
-  friend bool operator==(const PartitionDeletion&, const PartitionDeletion&);
+class DeletionTime {
+  friend bool operator==(const DeletionTime&, const DeletionTime&);
 
  public:
-  PartitionDeletion(const Slice& partition_key, int32_t local_deletion_time,
-                    int64_t marked_for_delete_at);
-  PartitionDeletion(const PartitionDeletion& pd);
+  DeletionTime(int32_t local_deletion_time, int64_t marked_for_delete_at)
+      : local_deletion_time_(local_deletion_time),
+        marked_for_delete_at_(marked_for_delete_at) {}
 
-  std::chrono::time_point<std::chrono::system_clock> MarkForDeleteAt() const;
-  std::chrono::time_point<std::chrono::system_clock> LocalDeletionTime() const;
-  const Slice PartitionKey() const;
-  bool Supersedes(std::unique_ptr<PartitionDeletion>& pd) const;
-  static PartitionDeletions Merge(PartitionDeletions&& pds);
-  static PartitionDeletions Deserialize(const char* src, std::size_t size);
-  static void Serialize(PartitionDeletions&& pds, std::string* dest);
-  const static std::size_t kMinSize;
+  std::chrono::time_point<std::chrono::system_clock> MarkForDeleteAt() const {
+    return std::chrono::time_point<std::chrono::system_clock>(
+        std::chrono::microseconds(marked_for_delete_at_));
+  }
+
+  std::chrono::time_point<std::chrono::system_clock> LocalDeletionTime() const {
+    return std::chrono::time_point<std::chrono::system_clock>(
+        std::chrono::seconds(local_deletion_time_));
+  }
+
+  bool Supersedes(const DeletionTime& other) const {
+    return marked_for_delete_at_ > other.marked_for_delete_at_ ||
+           (marked_for_delete_at_ == other.marked_for_delete_at_ &&
+            local_deletion_time_ > other.local_deletion_time_);
+  }
+
+  void Serialize(std::string* dest) const;
+  static const DeletionTime Deserialize(const char* src, std::size_t size);
+  const static size_t kSize;
+  const static DeletionTime kLive;
 
  private:
-  const Slice partition_key_;
   int32_t local_deletion_time_;
   int64_t marked_for_delete_at_;
 };
 
+inline bool operator==(const DeletionTime& x, const DeletionTime& y) {
+  return x.local_deletion_time_ == y.local_deletion_time_ &&
+         x.marked_for_delete_at_ == y.marked_for_delete_at_;
+}
+
+inline bool operator!=(const DeletionTime& x, const DeletionTime& y) {
+  return !(x == y);
+}
+
+class PartitionDeletion;
+typedef std::vector<std::unique_ptr<PartitionDeletion>> PartitionDeletions;
+
+class PartitionDeletion {
+ public:
+  PartitionDeletion(const Slice& partition_key,
+                    const DeletionTime& deletion_time);
+  PartitionDeletion(const PartitionDeletion& pd);
+
+  const DeletionTime& GetDeletionTime() const;
+  const Slice PartitionKey() const;
+  static PartitionDeletions Merge(PartitionDeletions&& pds);
+  static PartitionDeletions Deserialize(const char* src, std::size_t size);
+  static void Serialize(PartitionDeletions&& pds, std::string* dest);
+
+ private:
+  const Slice partition_key_;
+  const DeletionTime deletion_time_;
+  bool Supersedes(std::unique_ptr<PartitionDeletion>& pd) const;
+};
+
 inline bool operator==(const PartitionDeletion& x, const PartitionDeletion& y) {
   return x.PartitionKey() == y.PartitionKey() &&
-         x.local_deletion_time_ == y.local_deletion_time_ &&
-         x.marked_for_delete_at_ == y.marked_for_delete_at_;
+         x.GetDeletionTime() == y.GetDeletionTime();
 }
 
 inline bool operator!=(const PartitionDeletion& x, const PartitionDeletion& y) {

--- a/utilities/cassandra/merge_operator.cc
+++ b/utilities/cassandra/merge_operator.cc
@@ -74,19 +74,19 @@ bool CassandraPartitionMetaMergeOperator::FullMergeV2(
     for (auto& pd :
          PartitionDeletion::Deserialize(merge_in.existing_value->data(),
                                         merge_in.existing_value->size())) {
-      pds.push_back(pd);
+      pds.push_back(std::move(pd));
     }
   }
 
   for (auto& operand : merge_in.operand_list) {
     for (auto& pd :
          PartitionDeletion::Deserialize(operand.data(), operand.size())) {
-      pds.push_back(pd);
+      pds.push_back(std::move(pd));
     }
   }
 
-  PartitionDeletions merged = PartitionDeletion::Merge(pds);
-  PartitionDeletion::Serialize(merged, &(merge_out->new_value));
+  PartitionDeletions merged = PartitionDeletion::Merge(std::move(pds));
+  PartitionDeletion::Serialize(std::move(merged), &(merge_out->new_value));
   return true;
 }
 
@@ -102,12 +102,12 @@ bool CassandraPartitionMetaMergeOperator::PartialMergeMulti(
   for (auto& operand : operand_list) {
     for (auto& pd :
          PartitionDeletion::Deserialize(operand.data(), operand.size())) {
-      pds.push_back(pd);
+      pds.push_back(std::move(pd));
     }
   }
 
-  PartitionDeletions merged = PartitionDeletion::Merge(pds);
-  PartitionDeletion::Serialize(merged, new_value);
+  PartitionDeletions merged = PartitionDeletion::Merge(std::move(pds));
+  PartitionDeletion::Serialize(std::move(merged), new_value);
   return true;
 }
 

--- a/utilities/cassandra/partition_meta_data.cc
+++ b/utilities/cassandra/partition_meta_data.cc
@@ -76,5 +76,12 @@ Status PartitionMetaData::DeletePartition(const Slice& partition_key_with_token,
   return db_->Merge(write_option_, meta_cf_handle_, token, val);
 }
 
+Status PartitionMetaData::ApplyRaw(const Slice& key, const Slice& value) {
+  if (enable_bloom_) {
+    bloom_.AddConcurrently(key);
+  }
+  return db_->Merge(write_option_, meta_cf_handle_, key, value);
+}
+
 }  // namespace cassandra
 }  // namespace rocksdb

--- a/utilities/cassandra/partition_meta_data.cc
+++ b/utilities/cassandra/partition_meta_data.cc
@@ -1,0 +1,48 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "utilities/cassandra/partition_meta_data.h"
+
+namespace rocksdb {
+namespace cassandra {
+std::unique_ptr<PartitionDeletion> PartitionMetaData::GetPartitionDelete(
+    const Slice& key) const {
+  if (key.size() < token_length_) {
+    return nullptr;
+  }
+
+  Slice token(key.data(), token_length_);
+  Slice key_wo_token(key.data() + token_length_, key.size() - token_length_);
+  std::string val;
+
+  if (db_->Get(read_options_, meta_cf_handle_, token, &val).ok()) {
+    PartitionDeletions pds =
+        PartitionDeletion::Deserialize(val.data(), val.size());
+    for (auto& pd : pds) {
+      if (key_wo_token.starts_with(pd->PartitionKey())) {
+        return std::move(pd);
+      }
+    }
+  }
+  return nullptr;
+}
+
+Status PartitionMetaData::DeletePartition(const Slice& partition_key_with_token,
+                                          int32_t local_deletion_time,
+                                          int64_t marked_for_delete_at) {
+  Slice token(partition_key_with_token.data(), token_length_);
+  Slice partition_key(partition_key_with_token.data() + token_length_,
+                      partition_key_with_token.size() - token_length_);
+  PartitionDeletions pds;
+  pds.reserve(1);
+  pds.push_back(std::unique_ptr<PartitionDeletion>(new PartitionDeletion(
+      partition_key, local_deletion_time, marked_for_delete_at)));
+  std::string val;
+  PartitionDeletion::Serialize(std::move(pds), &val);
+  return db_->Merge(write_option_, meta_cf_handle_, token, val);
+}
+
+}  // namespace cassandra
+}  // namespace rocksdb

--- a/utilities/cassandra/partition_meta_data.cc
+++ b/utilities/cassandra/partition_meta_data.cc
@@ -7,15 +7,36 @@
 
 namespace rocksdb {
 namespace cassandra {
+
+PartitionMetaData::PartitionMetaData(DB* db, ColumnFamilyHandle* meta_cf_handle,
+                                     size_t token_length)
+    : db_(db),
+      meta_cf_handle_(meta_cf_handle),
+      token_length_(token_length),
+      enable_bloom_(false),
+      bloom_(6, nullptr) {
+  read_options_.ignore_range_deletions = true;
+};
+
+Status PartitionMetaData::EnableBloomFilter(uint32_t bloom_total_bits) {
+  bloom_.SetTotalBits(&arena_, bloom_total_bits, 0, 0, nullptr);
+  rocksdb::Iterator* it = db_->NewIterator(read_options_, meta_cf_handle_);
+  for (it->SeekToFirst(); it->Valid(); it->Next()) {
+    bloom_.Add(it->key());
+  }
+  Status result = it->status();
+  delete it;
+  enable_bloom_ = true;
+  return result;
+}
+
 DeletionTime PartitionMetaData::GetDeletionTime(const Slice& row_key) const {
   if (row_key.size() < token_length_) {
     return DeletionTime::kLive;
   }
 
   Slice token(row_key.data(), token_length_);
-  // do a quick key existing check without hitting disk
-  std::string tmp;
-  if (!db_->KeyMayExist(read_options_, meta_cf_handle_, token, &tmp)) {
+  if (enable_bloom_ && !bloom_.MayContain(token)) {
     return DeletionTime::kLive;
   }
 
@@ -39,6 +60,11 @@ Status PartitionMetaData::DeletePartition(const Slice& partition_key_with_token,
                                           int32_t local_deletion_time,
                                           int64_t marked_for_delete_at) {
   Slice token(partition_key_with_token.data(), token_length_);
+
+  if (enable_bloom_) {
+    bloom_.AddConcurrently(token);
+  }
+
   Slice partition_key(partition_key_with_token.data() + token_length_,
                       partition_key_with_token.size() - token_length_);
   PartitionDeletions pds;

--- a/utilities/cassandra/partition_meta_data.cc
+++ b/utilities/cassandra/partition_meta_data.cc
@@ -7,14 +7,14 @@
 
 namespace rocksdb {
 namespace cassandra {
-std::unique_ptr<PartitionDeletion> PartitionMetaData::GetPartitionDelete(
-    const Slice& key) const {
-  if (key.size() < token_length_) {
-    return nullptr;
+DeletionTime PartitionMetaData::GetDeletionTime(const Slice& row_key) const {
+  if (row_key.size() < token_length_) {
+    return DeletionTime::kLive;
   }
 
-  Slice token(key.data(), token_length_);
-  Slice key_wo_token(key.data() + token_length_, key.size() - token_length_);
+  Slice token(row_key.data(), token_length_);
+  Slice key_wo_token(row_key.data() + token_length_,
+                     row_key.size() - token_length_);
   std::string val;
 
   if (db_->Get(read_options_, meta_cf_handle_, token, &val).ok()) {
@@ -22,11 +22,11 @@ std::unique_ptr<PartitionDeletion> PartitionMetaData::GetPartitionDelete(
         PartitionDeletion::Deserialize(val.data(), val.size());
     for (auto& pd : pds) {
       if (key_wo_token.starts_with(pd->PartitionKey())) {
-        return std::move(pd);
+        return pd->GetDeletionTime();
       }
     }
   }
-  return nullptr;
+  return DeletionTime::kLive;
 }
 
 Status PartitionMetaData::DeletePartition(const Slice& partition_key_with_token,
@@ -38,7 +38,7 @@ Status PartitionMetaData::DeletePartition(const Slice& partition_key_with_token,
   PartitionDeletions pds;
   pds.reserve(1);
   pds.push_back(std::unique_ptr<PartitionDeletion>(new PartitionDeletion(
-      partition_key, local_deletion_time, marked_for_delete_at)));
+      partition_key, DeletionTime(local_deletion_time, marked_for_delete_at))));
   std::string val;
   PartitionDeletion::Serialize(std::move(pds), &val);
   return db_->Merge(write_option_, meta_cf_handle_, token, val);

--- a/utilities/cassandra/partition_meta_data.cc
+++ b/utilities/cassandra/partition_meta_data.cc
@@ -13,6 +13,12 @@ DeletionTime PartitionMetaData::GetDeletionTime(const Slice& row_key) const {
   }
 
   Slice token(row_key.data(), token_length_);
+  // do a quick key existing check without hitting disk
+  std::string tmp;
+  if (!db_->KeyMayExist(read_options_, meta_cf_handle_, token, &tmp)) {
+    return DeletionTime::kLive;
+  }
+
   Slice key_wo_token(row_key.data() + token_length_,
                      row_key.size() - token_length_);
   std::string val;

--- a/utilities/cassandra/partition_meta_data.h
+++ b/utilities/cassandra/partition_meta_data.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+#include "rocksdb/db.h"
+#include "rocksdb/slice.h"
+#include "utilities/cassandra/format.h"
+namespace rocksdb {
+namespace cassandra {
+
+/**
+ * PartitionMetaData is for managing meta data (such as partition deletion) for
+ * each cassandra partitions. It should be initialized per rocksdb instance.
+ */
+class PartitionMetaData {
+ public:
+  PartitionMetaData(DB* db, ColumnFamilyHandle* meta_cf_handle,
+                    size_t token_length)
+      : db_(db), meta_cf_handle_(meta_cf_handle), token_length_(token_length) {
+    read_options_.ignore_range_deletions = true;
+  };
+
+  Status DeletePartition(const Slice& partition_key_with_token,
+                         int32_t local_deletion_time,
+                         int64_t marked_for_delete_at);
+  std::unique_ptr<PartitionDeletion> GetPartitionDelete(const Slice& key) const;
+
+ private:
+  DB* db_;
+  ColumnFamilyHandle* meta_cf_handle_;
+  size_t token_length_;
+  ReadOptions read_options_;
+  WriteOptions write_option_;
+};
+
+}  // namespace cassandra
+}  // namespace rocksdb

--- a/utilities/cassandra/partition_meta_data.h
+++ b/utilities/cassandra/partition_meta_data.h
@@ -6,6 +6,8 @@
 #pragma once
 #include "rocksdb/db.h"
 #include "rocksdb/slice.h"
+#include "util/arena.h"
+#include "util/dynamic_bloom.h"
 #include "utilities/cassandra/format.h"
 namespace rocksdb {
 namespace cassandra {
@@ -17,20 +19,26 @@ namespace cassandra {
 class PartitionMetaData {
  public:
   PartitionMetaData(DB* db, ColumnFamilyHandle* meta_cf_handle,
-                    size_t token_length)
-      : db_(db), meta_cf_handle_(meta_cf_handle), token_length_(token_length) {
-    read_options_.ignore_range_deletions = true;
-  };
+                    size_t token_length);
+
+  // Enable meta key bloom filter to filter out none exists key
+  // quickly. This helps boost performance when number of deleted
+  // partition key is only fraction of number of all keys
+  Status EnableBloomFilter(uint32_t bloom_total_bits_);
 
   Status DeletePartition(const Slice& partition_key_with_token,
                          int32_t local_deletion_time,
                          int64_t marked_for_delete_at);
+
   DeletionTime GetDeletionTime(const Slice& row_key) const;
 
  private:
   DB* db_;
   ColumnFamilyHandle* meta_cf_handle_;
   size_t token_length_;
+  bool enable_bloom_;
+  DynamicBloom bloom_;
+  Arena arena_;
   ReadOptions read_options_;
   WriteOptions write_option_;
 };

--- a/utilities/cassandra/partition_meta_data.h
+++ b/utilities/cassandra/partition_meta_data.h
@@ -30,6 +30,9 @@ class PartitionMetaData {
                          int32_t local_deletion_time,
                          int64_t marked_for_delete_at);
 
+  // apply raw partition meta data, useful for streaming case
+  Status ApplyRaw(const Slice& key, const Slice& value);
+
   DeletionTime GetDeletionTime(const Slice& row_key) const;
 
  private:

--- a/utilities/cassandra/partition_meta_data.h
+++ b/utilities/cassandra/partition_meta_data.h
@@ -25,7 +25,7 @@ class PartitionMetaData {
   Status DeletePartition(const Slice& partition_key_with_token,
                          int32_t local_deletion_time,
                          int64_t marked_for_delete_at);
-  std::unique_ptr<PartitionDeletion> GetPartitionDelete(const Slice& key) const;
+  DeletionTime GetDeletionTime(const Slice& row_key) const;
 
  private:
   DB* db_;

--- a/utilities/cassandra/test_utils.cc
+++ b/utilities/cassandra/test_utils.cc
@@ -71,17 +71,5 @@ int64_t ToMicroSeconds(int64_t seconds) {
 int32_t ToSeconds(int64_t microseconds) {
   return (int32_t)(microseconds / (int64_t)1000000);
 }
-
-std::chrono::time_point<std::chrono::system_clock> TimePointFromSeconds(
-    int64_t t) {
-  return std::chrono::time_point<std::chrono::system_clock>(
-      std::chrono::seconds(t));
-}
-
-std::chrono::time_point<std::chrono::system_clock> TimePointFromMicroSeconds(
-    int64_t t) {
-  return std::chrono::time_point<std::chrono::system_clock>(
-      std::chrono::microseconds(t));
-}
 }
 }

--- a/utilities/cassandra/test_utils.cc
+++ b/utilities/cassandra/test_utils.cc
@@ -71,5 +71,17 @@ int64_t ToMicroSeconds(int64_t seconds) {
 int32_t ToSeconds(int64_t microseconds) {
   return (int32_t)(microseconds / (int64_t)1000000);
 }
+
+std::chrono::time_point<std::chrono::system_clock> TimePointFromSeconds(
+    int64_t t) {
+  return std::chrono::time_point<std::chrono::system_clock>(
+      std::chrono::seconds(t));
+}
+
+std::chrono::time_point<std::chrono::system_clock> TimePointFromMicroSeconds(
+    int64_t t) {
+  return std::chrono::time_point<std::chrono::system_clock>(
+      std::chrono::microseconds(t));
+}
 }
 }

--- a/utilities/cassandra/test_utils.h
+++ b/utilities/cassandra/test_utils.h
@@ -42,5 +42,9 @@ void VerifyRowValueColumns(
 
 int64_t ToMicroSeconds(int64_t seconds);
 int32_t ToSeconds(int64_t microseconds);
+std::chrono::time_point<std::chrono::system_clock> TimePointFromSeconds(
+    int64_t t);
+std::chrono::time_point<std::chrono::system_clock> TimePointFromMicroSeconds(
+    int64_t t);
 }
 }

--- a/utilities/cassandra/test_utils.h
+++ b/utilities/cassandra/test_utils.h
@@ -42,9 +42,5 @@ void VerifyRowValueColumns(
 
 int64_t ToMicroSeconds(int64_t seconds);
 int32_t ToSeconds(int64_t microseconds);
-std::chrono::time_point<std::chrono::system_clock> TimePointFromSeconds(
-    int64_t t);
-std::chrono::time_point<std::chrono::system_clock> TimePointFromMicroSeconds(
-    int64_t t);
 }
 }


### PR DESCRIPTION
* use token as partition meta data key instead of var length partition key to avoid expensive scan.
* use bloom filter filter out non-existing partition meta data keys to save cpu cost during compaction